### PR TITLE
Misc fixes (as discussed online)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ REBAR=./rebar
 all: compile
 
 rebar:
-	wget https://github.com/downloads/basho/rebar/rebar -O $(REBAR)
+	curl -L -O https://github.com/downloads/basho/rebar/rebar
 	chmod u+x $(REBAR)
 
 compile: rebar

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,5 @@
 {require_otp_vsn, "R14|R15"}.
 
+{port_env, [{"LDFLAGS", "$LDFLAGS -liconv"}]}.
 {port_specs, [{"priv/eiconv_nif.so", ["c_src/*.c"]}]}.
+

--- a/src/eiconv.erl
+++ b/src/eiconv.erl
@@ -27,10 +27,10 @@ open(_ToCode, _FromCode) ->
 conv(_Cd, _Input) ->
     exit(nif_library_not_loaded).
 
-% @doc Close the encoder.
+% @doc Close the encoder - dummy function, close will be done by the garbage collector.
 %
 close(_Cd) ->
-    exit(nif_library_not_loaded).
+    ok.
 
 
 % @doc Convert input FromEncoding to utf-8


### PR DESCRIPTION
- Fetch rebar using curl
- Fix memory free error after an iconv error
- Allow character sets for iconv open to be binaries
- Make close a dummy call, as it is not defined in the nif C code
- Link the iconv library into the .so
