### PR TITLE
Remove OTP version constraint

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,2 @@
-{require_otp_vsn, "R14|R15"}.
 {port_env, [{"freebsd|darwin", "LDFLAGS", "$LDFLAGS -liconv"}]}.
 {port_specs, [{"priv/eiconv_nif.so", ["c_src/*.c"]}]}.


### PR DESCRIPTION
Hardcoding allowed versions has been inconvenient as it required a new commit for each Erlang release, while it can be assumed that newer releases will usually not break eiconv.